### PR TITLE
Update Threat Hunting BYOVD Scenarios.kql

### DIFF
--- a/DefenderXDR/Threat Hunting BYOVD Scenarios.kql
+++ b/DefenderXDR/Threat Hunting BYOVD Scenarios.kql
@@ -6,8 +6,8 @@ let DriverwithLowPrevalence =
 DeviceFileEvents
 | where ActionType == "FileCreated"
 | where FileName endswith ".sys"
-| invoke FileProfile(SHA1,10000)
-| where GlobalPrevalence <= 150
+| invoke FileProfile(SHA1,1000)
+| where GlobalPrevalence <= 150 or isempty(GlobalPrevalence)
 | join kind=leftouter DeviceFileCertificateInfo on SHA1
 | project FileName;
 DeviceEvents


### PR DESCRIPTION
Nice query! :)

The line below only filters non-null values, if the global prevalence of a file is unknown it will thus not appear in the results. Therefore it is best practice to always either filter on smaller/bigger than or isnull(GlobalPrevalence) 

```KQL
| where GlobalPrevalence <= 150
```

Ps. The FileProfile is limited to 1000 hashes. If there are more than 1000 .sys files created only the first 1000 can be enriched. It might be good to summarize, distinct before invoking FileProfile().
