### PR TITLE
Update Detecting Mamba 2FA phishing-as-a-service.kql

### DIFF
--- a/Sentinel/Detecting Mamba 2FA phishing-as-a-service.kql
+++ b/Sentinel/Detecting Mamba 2FA phishing-as-a-service.kql
@@ -18,7 +18,8 @@ let DomainsIOC = dynamic(['ccokies1cakes.com','ccokies2mangoes.com','ccokies3tom
 DeviceNetworkEvents
 | where TimeGenerated > ago(90d)
 | where ActionType == "HttpConnectionInspected"
-| extend WWWHost = AdditionalFields.host
+| extend parsedAdditionalFields = parse_json(AdditionalFields)
+| extend WWWHost = parsedAdditionalFields.host
 | where WWWHost has_any (DomainsIOC)
 
 // MITRE ATT&CK


### PR DESCRIPTION
AdditionalFields need to be parsed as json before WWWHost can be extended