### PR TITLE
Update Detecting Misconfigured EXO Transport Rules.kql

### DIFF
--- a/DefenderXDR/Detecting Misconfigured EXO Transport Rules.kql
+++ b/DefenderXDR/Detecting Misconfigured EXO Transport Rules.kql
@@ -2,7 +2,7 @@
 
 EmailEvents
 | where EmailDirection == "Inbound"
-| where isnotempty(ThreatClassification)
+| where isnotempty(ThreatTypes)
 | where LatestDeliveryAction == "Delivered"
 | where DeliveryLocation != "Junk folder"
 | summarize Count=count() by tostring(parse_json(AdditionalFields)["TransportRuleGuid"])


### PR DESCRIPTION
ThreatClassification is only populated if the MDO LLM scanning finds any threats on the emails, this was only introduced recently and the field is not always populated. ThreatTypes will always be populated when there are any kind of detections on the email (Spam/Phish/Malware).