### PR TITLE
fix: remove redundant table definitions in IP search query

### DIFF
--- a/DefenderXDR/DefenderXDR Advanced Hunting All-In-One IP Search.kql
+++ b/DefenderXDR/DefenderXDR Advanced Hunting All-In-One IP Search.kql
@@ -2,10 +2,10 @@
 // https://www.linkedin.com/pulse/defenderxdr-advanced-hunting-all-in-one-ip-search-steven-lim-a2j7c/
 
 // This KQL query searches across these DefenderXDR log tables for the ip variable that is defined at the start:
-// AADSignInEventsBeta, AADSignInEventsBeta, CloudAppEvents, IdentityLogonEvents, UrlClickEvents, DeviceNetworkInfo, CloudAuditEvents, DeviceFileEvents, AlertEvidence, BehaviorEntities, DeviceEvents, DeviceLogonEvents, DeviceNetworkEvents, EmailEvents, DeviceInfo and ExposureGraphNodes
+// AADSignInEventsBeta, CloudAppEvents, IdentityLogonEvents, UrlClickEvents, DeviceNetworkInfo, CloudAuditEvents, DeviceFileEvents, AlertEvidence, BehaviorEntities, DeviceEvents, DeviceLogonEvents, DeviceNetworkEvents, EmailEvents, DeviceInfo and ExposureGraphNodes
 
 let ip = "223.171.89.199"; // Sample Malicious IP
-search in (AADSignInEventsBeta, AADSignInEventsBeta, CloudAppEvents, IdentityLogonEvents, CloudAuditEvents, UrlClickEvents, DeviceNetworkInfo, CloudAuditEvents, DeviceFileEvents, AlertEvidence, ExposureGraphNodes, BehaviorEntities, DeviceEvents, DeviceLogonEvents, DeviceNetworkEvents, EmailEvents, DeviceInfo)
+search in (AADSignInEventsBeta, CloudAppEvents, IdentityLogonEvents, CloudAuditEvents, UrlClickEvents, DeviceNetworkInfo, DeviceFileEvents, AlertEvidence, ExposureGraphNodes, BehaviorEntities, DeviceEvents, DeviceLogonEvents, DeviceNetworkEvents, EmailEvents, DeviceInfo)
 Timestamp between (ago(7d) .. now())
 and (
 // AADSignInEventsBeta AADSpnSignInEventsBeta CloudAppEvents IdentityLogonEvents


### PR DESCRIPTION
The IP search query in `DefenderXDR/DefenderXDR Advanced Hunting All-In-One IP Search.kql` contained redundant table definitions within the `search in` operator and the introductory comment. Specifically, `AADSignInEventsBeta` and `CloudAuditEvents` were listed multiple times. These redundancies introduce unnecessary processing overhead to the KQL engine. The query and its documentation have been cleaned to include each unique table exactly once, ensuring more efficient execution while maintaining full coverage.