### PR TITLE
Enhance KQL query for IPv6 private IP checks

### DIFF
--- a/DefenderXDR/Endpoint SMB exposed on Public Internet.kql
+++ b/DefenderXDR/Endpoint SMB exposed on Public Internet.kql
@@ -17,6 +17,10 @@ DeviceNetworkEvents
 | where LocalPort == "445"
 | where RemoteIPType == @"Public"
 | where not (ipv4_is_private(LocalIP))
+// KQL does not currently have a IPv6 private check function
+| where not(LocalIP startswith "fe80:") // IPv6 Link-local
+| where not(LocalIP startswith "fc") // IPv6 ULA
+| where not(LocalIP startswith "fd") // IPv6 ULA
 
 
 


### PR DESCRIPTION
Added checks for IPv6 link-local and ULA addresses to the KQL query.